### PR TITLE
Enable Daily Dependabot for Maven, GitHub Actions & Pages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,17 @@
 
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: maven
+    directory: /
     schedule:
-      interval: "daily" # How often Dependabot shall scan and push dependency updates to the repository.
+      interval: daily
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: bundler
+    directory: /docs
+    schedule:
+      interval: daily


### PR DESCRIPTION
> Enables daily Dependabot updates for `maven`, `github-actions` and `bundle` (GitHub Pages).