### PR TITLE
Use `Label-Auditor` GitHub Action

### DIFF
--- a/.github/workflows/pullRequestAudit.yml
+++ b/.github/workflows/pullRequestAudit.yml
@@ -17,21 +17,9 @@ jobs:
   Label-Auditor:
     name: Label Auditor
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
 
     steps:
-      - uses: actions/github-script@v9
-        with:
-          script: |
-            const categoriesRequiringSemanticVersion = ['feature', 'bug', 'javadocs'];
-            const requiredCategories = ['feature', 'bug', 'documentation', 'test', 'dependencies', 'meta', 'javadocs', 'refactor'];
-            const semanticVersions = ['MAJOR', 'MINOR', 'PATCH'];
-
-            const labels = context.payload.pull_request.labels;
-            if (labels.filter(label => requiredCategories.includes(label.name)).length == 0) {
-              throw new Error(`Pull Request requires one of the following labels: ${requiredCategories.join(', ')}`);
-            }
-            if (labels.filter(label => categoriesRequiringSemanticVersion.includes(label.name)).length > 0) {
-              if (labels.filter(label => semanticVersions.includes(label.name)).length == 0) {
-                throw new Error(`Pull Request requires a 'Semantic version'-label for the following labels: ${categoriesRequiringSemanticVersion.join(', ')}`);
-              }
-            }
+      - name: Label Auditor
+        uses: Chrimle/Label-Auditor@v0.1.0


### PR DESCRIPTION
> Replace implementation of Label Auditor with the centralized and published [`Label-Auditor` GitHub Action](https://github.com/Chrimle/Label-Auditor).